### PR TITLE
Enable dynamic input switching

### DIFF
--- a/core/java/android/view/ViewRootImpl.java
+++ b/core/java/android/view/ViewRootImpl.java
@@ -155,6 +155,7 @@ public final class ViewRootImpl implements ViewParent,
     public static final String PROPERTY_EMULATOR_WIN_OUTSET_BOTTOM_PX =
             "ro.emu.win_outset_bottom_px";
 
+    private static final String PROPERTY_MARUOS_DESKTOP_INTERACTIVE = "sys.maruos.desktop.interactive";
     /**
      * Maximum time we allow the user to roll the trackball enough to generate
      * a key event, before resetting the counters.
@@ -4204,6 +4205,13 @@ public final class ViewRootImpl implements ViewParent,
         }
 
         protected boolean shouldDropInputEvent(QueuedInputEvent q) {
+            boolean isDesktopInteractive =
+                    SystemProperties.getBoolean(PROPERTY_MARUOS_DESKTOP_INTERACTIVE, false);
+            InputDevice device = q.mEvent == null ? null : q.mEvent.getDevice();
+            boolean isExternal = device != null && device.isExternal();
+            if (isDesktopInteractive && isExternal) {
+                return true;
+            }
             if (mView == null || !mAdded) {
                 Slog.w(mTag, "Dropping event due to root view being removed: " + q.mEvent);
                 return true;

--- a/services/core/java/com/android/server/mperspective/PerspectiveService.java
+++ b/services/core/java/com/android/server/mperspective/PerspectiveService.java
@@ -21,6 +21,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ComponentName;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.hardware.display.DisplayManager;
@@ -35,6 +36,7 @@ import android.os.Message;
 import android.os.RemoteException;
 import android.os.SystemProperties;
 import android.os.UserHandle;
+import android.provider.Settings;
 import android.util.Log;
 import android.util.SparseArray;
 import android.view.Display;
@@ -87,6 +89,7 @@ public class PerspectiveService extends IPerspectiveService.Stub {
     }
 
     private Context mContext;
+    private ContentResolver mResolver;
     private DisplayManager mDisplayManager;
     private NotificationManager mNotificationManager;
 
@@ -117,6 +120,7 @@ public class PerspectiveService extends IPerspectiveService.Stub {
 
     public PerspectiveService(Context context) {
         mContext = context;
+        mResolver = mContext == null ? null : mContext.getContentResolver();
         mDisplayListener = new MDisplayListener();
         mCallbacks = new SparseArray<CallbackWrapper>();
         mHandler = new PerspectiveHandler(FgThread.get().getLooper());
@@ -156,6 +160,16 @@ public class PerspectiveService extends IPerspectiveService.Stub {
         boolean updateResult = nativeEnableInput(mNativeClient, enable);
         if (!updateResult) {
             Log.w(TAG, "Update desktop interactive state failed");
+        } else {
+            if (mResolver != null) {
+                Settings.Secure.putInt(
+                        mResolver,
+                        Settings.Secure.SHOW_IME_WITH_HARD_KEYBOARD,
+                        enable ? 1 : 0
+                );
+            } else {
+                Log.w(TAG, "Set SHOW_IME_WITH_HARD_KEYBOARD failed because of the mResolver is null");
+            }
         }
     }
 

--- a/services/core/jni/com_android_server_mperspective_PerspectiveService.cpp
+++ b/services/core/jni/com_android_server_mperspective_PerspectiveService.cpp
@@ -76,6 +76,10 @@ public:
         return mProxy != NULL && mProxy->isRunning();
     }
 
+    bool enableInput(bool enable) {
+        return mProxy != NULL && mProxy->enableInput(enable);
+    }
+
 private:
     sp<IPerspectiveService> mProxy;
 
@@ -119,6 +123,11 @@ static jboolean nativeIsRunning(JNIEnv *env, jclass clazz, jlong ptr) {
     return client->isRunning();
 }
 
+static jboolean nativeEnableInput(JNIEnv *env, jclass clazz, jlong ptr, jboolean enable) {
+    PerspectiveClient *client = reinterpret_cast<PerspectiveClient*>(ptr);
+    return client->enableInput(enable);
+}
+
 static JNINativeMethod gMethods[] = {
     /* name, signature, funcPtr */
     { "nativeCreateClient", "()J",
@@ -128,7 +137,9 @@ static JNINativeMethod gMethods[] = {
     { "nativeStop", "(J)Z",
             (void *)nativeStop },
     { "nativeIsRunning", "(J)Z",
-            (void *)nativeIsRunning }
+            (void *)nativeIsRunning },
+    { "nativeEnableInput", "(JZ)Z",
+            (void *)nativeEnableInput}
 };
 
 int register_android_server_mperspective_PerspectiveService(JNIEnv* env) {


### PR DESCRIPTION
The `frameworks_base` part to enable dynamic input switching. For the whose view, please visit the issue [Enable dynamic input switching](https://github.com/maruos/maruos/issues/97).