### PR TITLE
Port display modifications for maru-0.7

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,4 +1,6 @@
 // Copyright (C) 2016 The Android Open Source Project
+// Copyright (C) 2015-2016 Preetam J. D'Souza
+// Copyright (C) 2016-2021 The Maru OS Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -184,6 +186,8 @@ java_library {
         "core/java/android/hardware/radio/ITunerCallback.aidl",
         "core/java/android/hardware/soundtrigger/IRecognitionStatusCallback.aidl",
         "core/java/android/hardware/usb/IUsbManager.aidl",
+        "core/java/android/mperspective/IPerspectiveService.aidl",
+        "core/java/android/mperspective/IPerspectiveServiceCallback.aidl",
         "core/java/android/net/ICaptivePortal.aidl",
         "core/java/android/net/IConnectivityManager.aidl",
         "core/java/android/net/IIpConnectivityMetrics.aidl",

--- a/NOTICE
+++ b/NOTICE
@@ -104,6 +104,18 @@ These files are Copyright (C) 2004-2010 NXP Software and
 Copyright (C) 2010 The Android Open Source Project, but released under
 the Apache2 License.
 
+  =========================================================================
+  ==  NOTICE file corresponding to the section 4 d of                    ==
+  ==  the Apache License, Version 2.0,                                   ==
+  ==  in this case for Maru OS code.                                     ==
+  =========================================================================
+
+Maru OS Code
+Copyright 2015-2016 Preetam J. D'Souza
+Copyright 2016 The Maru OS Project
+
+This product includes software initially developed by Preetam J. D'Souza
+and later open-sourced under The Maru OS Project (http://maruos.com).
 
                                Apache License
                            Version 2.0, January 2004

--- a/core/java/android/app/SystemServiceRegistry.java
+++ b/core/java/android/app/SystemServiceRegistry.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2015 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +77,8 @@ import android.media.session.MediaSessionManager;
 import android.media.soundtrigger.SoundTriggerManager;
 import android.media.tv.ITvInputManager;
 import android.media.tv.TvInputManager;
+import android.mperspective.IPerspectiveService;
+import android.mperspective.PerspectiveManager;
 import android.net.ConnectivityManager;
 import android.net.ConnectivityThread;
 import android.net.EthernetManager;
@@ -561,6 +565,14 @@ final class SystemServiceRegistry {
             public SerialManager createService(ContextImpl ctx) throws ServiceNotFoundException {
                 IBinder b = ServiceManager.getServiceOrThrow(Context.SERIAL_SERVICE);
                 return new SerialManager(ctx, ISerialManager.Stub.asInterface(b));
+            }});
+
+        registerService(Context.PERSPECTIVE_SERVICE, PerspectiveManager.class,
+                new CachedServiceFetcher<PerspectiveManager>() {
+            @Override
+            public PerspectiveManager createService(ContextImpl ctx) {
+                IBinder b = ServiceManager.getService(Context.PERSPECTIVE_SERVICE);
+                return new PerspectiveManager(IPerspectiveService.Stub.asInterface(b));
             }});
 
         registerService(Context.VIBRATOR_SERVICE, Vibrator.class,

--- a/core/java/android/content/Context.java
+++ b/core/java/android/content/Context.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2006 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4217,6 +4219,15 @@ public abstract class Context {
      */
     @SystemApi
     public static final String SECURE_ELEMENT_SERVICE = "secure_element";
+    /*
+     * Use with {@link #getSystemService} to retrieve a {@link
+     * android.mperspective.PerspectiveManager} instance for managing
+     * perspectives.
+     * @see #getSystemService
+     * @see android.mperspective.PerspectiveManager
+     * @hide
+     */
+    public static final String PERSPECTIVE_SERVICE = "perspective";
 
     /**
      * Determine whether the given permission is allowed for a particular

--- a/core/java/android/hardware/display/DisplayManager.java
+++ b/core/java/android/hardware/display/DisplayManager.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2012 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,6 +425,33 @@ public final class DisplayManager {
      */
     public void unregisterDisplayListener(DisplayListener listener) {
         mGlobal.unregisterDisplayListener(listener);
+    }
+
+    /**
+     * maru: enable screen mirroring
+     *
+     * @hide
+     */
+    public void enablePhoneMirroring() {
+        mGlobal.enablePhoneMirroring();
+    }
+
+    /**
+     * maru: disable screen mirroring
+     *
+     * @hide
+     */
+    public void disablePhoneMirroring() {
+        mGlobal.disablePhoneMirroring();
+    }
+
+    /**
+     * maru: check if screen mirroring is enabled or not
+     *
+     * @hide
+     */
+    public boolean isPhoneMirroringEnabled() {
+        return mGlobal.isPhoneMirroringEnabled();
     }
 
     /**

--- a/core/java/android/hardware/display/DisplayManagerGlobal.java
+++ b/core/java/android/hardware/display/DisplayManagerGlobal.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2012 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,6 +280,31 @@ public final class DisplayManagerGlobal {
                 mDisplayListeners.get(i).sendDisplayEvent(displayId, event);
             }
         }
+    }
+
+    public void enablePhoneMirroring() {
+        try {
+            mDm.enablePhoneMirroring();
+        } catch (RemoteException ex) {
+            Log.e(TAG, "Failed to enable mirroring with display manager service.", ex);
+        }
+    }
+
+    public void disablePhoneMirroring() {
+        try {
+            mDm.disablePhoneMirroring();
+        } catch (RemoteException ex) {
+            Log.e(TAG, "Failed to disable mirroring with display manager service.", ex);
+        }
+    }
+
+    public boolean isPhoneMirroringEnabled() {
+        try {
+            return mDm.isPhoneMirroringEnabled();
+        } catch (RemoteException ex) {
+            Log.e(TAG, "Failed to get mirroring configuration from display manager service.", ex);
+        }
+        return false;
     }
 
     public void startWifiDisplayScan() {

--- a/core/java/android/hardware/display/IDisplayManager.aidl
+++ b/core/java/android/hardware/display/IDisplayManager.aidl
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2012 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,4 +118,12 @@ interface IDisplayManager {
 
     // Get the minimum brightness curve.
     Curve getMinimumBrightnessCurve();
+    /**
+     * maru
+     *
+     * Mirroring support
+     */
+     void enablePhoneMirroring();
+     void disablePhoneMirroring();
+     boolean isPhoneMirroringEnabled();
 }

--- a/core/java/android/mperspective/IPerspectiveService.aidl
+++ b/core/java/android/mperspective/IPerspectiveService.aidl
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.mperspective;
+
+import android.mperspective.IPerspectiveServiceCallback;
+
+/**
+ * @hide
+ */
+interface IPerspectiveService {
+
+    void startDesktopPerspective();
+
+    void stopDesktopPerspective();
+
+    boolean isDesktopRunning();
+
+    void registerCallback(IPerspectiveServiceCallback callback);
+}

--- a/core/java/android/mperspective/IPerspectiveServiceCallback.aidl
+++ b/core/java/android/mperspective/IPerspectiveServiceCallback.aidl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.mperspective;
+
+/**
+ * @hide
+ */
+interface IPerspectiveServiceCallback {
+    oneway void onPerspectiveEvent(int event);
+}

--- a/core/java/android/mperspective/Perspective.java
+++ b/core/java/android/mperspective/Perspective.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.mperspective;
+
+/**
+ * Perspectives are interfaces to hardware.
+ *
+ * @hide
+ */
+public class Perspective {
+
+    public static final int STATE_STOPPED = 0;
+    public static final int STATE_STARTING = 1;
+    public static final int STATE_RUNNING = 2;
+    public static final int STATE_STOPPING = 3;
+
+    public static String stateToString(int state) {
+        switch (state) {
+            case Perspective.STATE_STARTING:
+                return "STARTING";
+            case Perspective.STATE_RUNNING:
+                return "RUNNING";
+            case Perspective.STATE_STOPPING:
+                return "STOPPING";
+            case Perspective.STATE_STOPPED:
+                return "STOPPED";
+            default:
+                return "UNKNOWN";
+        }
+    }
+
+}

--- a/core/java/android/mperspective/PerspectiveManager.java
+++ b/core/java/android/mperspective/PerspectiveManager.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.mperspective;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.os.RemoteException;
+import android.util.Log;
+
+/**
+ * System private Java interface to PerspectiveService.
+ *
+ * @hide
+ */
+public final class PerspectiveManager {
+    private static final String TAG = "PerspectiveManager";
+
+    private final IPerspectiveService mService;
+    private IPerspectiveServiceCallback mCallback;
+    private PerspectiveListenerHandler mListener;
+
+    public PerspectiveManager(final IPerspectiveService service) {
+        mService = service;
+    }
+
+    public void startDesktopPerspective() {
+        try {
+            mService.startDesktopPerspective();
+        } catch (RemoteException e) {
+            Log.e(TAG, "RemoteException starting desktop perspective", e);
+        }
+    }
+
+    public void stopDesktopPerspective() {
+        try {
+            mService.stopDesktopPerspective();
+        } catch (RemoteException e) {
+            Log.e(TAG, "RemoteException stopping desktop perspective", e);
+        }
+    }
+
+    public boolean isDesktopRunning() {
+        try {
+            return mService.isDesktopRunning();
+        } catch (RemoteException e) {
+            Log.e(TAG, "RemoteException checking desktop perspective state", e);
+        }
+        return false;
+    }
+
+    public void registerPerspectiveListener(final PerspectiveListener listener,
+                                            final Handler handler) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
+
+        mListener = new PerspectiveListenerHandler(listener, handler);
+        registerCallbackIfNeeded();
+    }
+
+    public void unregisterPerspectiveListener() {
+        mListener = null;
+        // TODO: unregister from service?
+    }
+
+    private void registerCallbackIfNeeded() {
+        if (mCallback == null) {
+            mCallback = new PerspectiveServiceCallback();
+            try {
+                mService.registerCallback(mCallback);
+            } catch (RemoteException e) {
+                Log.e(TAG, "RemoteException registering perspective callback", e);
+                mCallback = null;
+            }
+        }
+    }
+
+    private final class PerspectiveServiceCallback extends IPerspectiveServiceCallback.Stub {
+        @Override
+        public void onPerspectiveEvent(int event) {
+            if (mListener != null) {
+                mListener.sendPerspectiveEvent(event);
+            }
+        }
+    }
+
+    /**
+     * This class ensures that events are delivered to a listener on
+     * its original registering thread or specified alternate Handler.
+     */
+    private static final class PerspectiveListenerHandler extends Handler {
+        private PerspectiveListener mListener;
+
+        public PerspectiveListenerHandler(final PerspectiveListener listener,
+                                          final Handler handler) {
+            super(handler != null ? handler.getLooper() : Looper.myLooper());
+            mListener = listener;
+        }
+
+        public void sendPerspectiveEvent(int event) {
+            sendEmptyMessage(event);
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            mListener.onPerspectiveStateChanged(msg.what);
+        }
+    }
+
+    /**
+     * Listen for perspective lifecycle events.
+     */
+    public interface PerspectiveListener {
+
+        /**
+         *
+         * @param state One of {@link Perspective#STATE_STARTING},
+         *              {@link Perspective#STATE_RUNNING},
+         *              {@link Perspective#STATE_STOPPING},
+         *              {@link Perspective#STATE_STOPPED},
+         */
+        void onPerspectiveStateChanged(int state);
+    }
+}

--- a/core/java/android/view/Display.java
+++ b/core/java/android/view/Display.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2006 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +100,15 @@ public final class Display {
      * assuming there is one.
      */
     public static final int DEFAULT_DISPLAY = 0;
+
+    /**
+     * maru
+     *
+     * Fixed display id for the default external display. Currently only HDMI.
+     * The default Display id for the desktop, which is the id of Maru Desktop's "virtual" display.
+     * @hide
+     */
+    public static final int DEFAULT_DESKTOP_DISPLAY = 1;
 
     /**
      * Invalid display id.

--- a/services/core/java/com/android/server/display/DisplayDeviceInfo.java
+++ b/services/core/java/com/android/server/display/DisplayDeviceInfo.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2012 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +110,13 @@ final class DisplayDeviceInfo {
      * @hide
      */
     public static final int FLAG_MASK_DISPLAY_CUTOUT = 1 << 11;
+    /*
+     * maru
+     *
+     * Flag: Indicates that this display should be considered the
+     * default external display.
+     */
+    public static final int FLAG_DEFAULT_EXTERNAL_DISPLAY = 1 << 31;
 
     /**
      * Touch attachment: Display does not receive touch.
@@ -461,6 +470,9 @@ final class DisplayDeviceInfo {
         }
         if ((flags & FLAG_MASK_DISPLAY_CUTOUT) != 0) {
             msg.append(", FLAG_MASK_DISPLAY_CUTOUT");
+        }
+        if ((flags & FLAG_DEFAULT_EXTERNAL_DISPLAY) != 0) {
+            msg.append(", FLAG_DEFAULT_EXTERNAL_DISPLAY");
         }
         return msg.toString();
     }

--- a/services/core/java/com/android/server/display/DisplayManagerService.java
+++ b/services/core/java/com/android/server/display/DisplayManagerService.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2012 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,6 +188,11 @@ public final class DisplayManagerService extends SystemService {
     // services should be started.  This option may disable certain display adapters.
     public boolean mOnlyCore;
 
+    /**
+     * maru
+     */
+    private boolean mPhoneMirroringEnabled;
+
     // True if the display manager service should pretend there is only one display
     // and only tell applications about the existence of the default logical display.
     // The display manager can still mirror content to secondary displays but applications
@@ -206,7 +213,7 @@ public final class DisplayManagerService extends SystemService {
     // List of all logical displays indexed by logical display id.
     private final SparseArray<LogicalDisplay> mLogicalDisplays =
             new SparseArray<LogicalDisplay>();
-    private int mNextNonDefaultDisplayId = Display.DEFAULT_DISPLAY + 1;
+    private int mNextNonDefaultDisplayId = Display.DEFAULT_DESKTOP_DISPLAY + 1;
 
     // List of all display transaction listeners.
     private final CopyOnWriteArrayList<DisplayTransactionListener> mDisplayTransactionListeners =
@@ -613,6 +620,22 @@ public final class DisplayManagerService extends SystemService {
         synchronized (mSyncRoot) {
             mCallbacks.remove(record.mPid);
             stopWifiDisplayScanLocked(record);
+        }
+    }
+
+    private void setPhoneMirroringEnabledInternal(boolean enabled) {
+        synchronized(mSyncRoot) {
+            if (mPhoneMirroringEnabled != enabled) {
+                Slog.d(TAG, "setPhoneMirroringEnabledInternal -> " + enabled);
+                mPhoneMirroringEnabled = enabled;
+                scheduleTraversalLocked(false);
+            }
+        }
+    }
+
+    private boolean isPhoneMirroringEnabledInternal() {
+        synchronized(mSyncRoot) {
+            return mPhoneMirroringEnabled;
         }
     }
 
@@ -1263,6 +1286,7 @@ public final class DisplayManagerService extends SystemService {
     private void configureDisplayLocked(SurfaceControl.Transaction t, DisplayDevice device) {
         final DisplayDeviceInfo info = device.getDisplayDeviceInfoLocked();
         final boolean ownContent = (info.flags & DisplayDeviceInfo.FLAG_OWN_CONTENT_ONLY) != 0;
+        int layerStackOverride = -1;
 
         // Find the logical display that the display device is showing.
         // Certain displays only ever show their own content.
@@ -1274,10 +1298,24 @@ public final class DisplayManagerService extends SystemService {
                 display = null;
             }
             if (display == null) {
-                display = mLogicalDisplays.get(Display.DEFAULT_DISPLAY);
+                // This is the mirroring case.
+                //
+                // We basically swap between mirroring default display or desktop display.
+                // In the case of default display, there is a logical display around. But
+                // for desktop display, we don't have a logical display and just set the
+                // layerstack of the display device to the desktop's reserved layerstack.
+                if (isPhoneMirroringEnabledInternal()) {
+                    // Stock phone mirroring path
+                    display = mLogicalDisplays.get(Display.DEFAULT_DISPLAY);
+                } else {
+                    // Desktop mirroring path
+                    // Use the associated logical display for this device as usual
+                    display = findLogicalDisplayForDeviceLocked(device);
+                    // ...but override the logical display's layerstack with the desktop layerstack
+                    layerStackOverride = Display.DEFAULT_DESKTOP_DISPLAY;
+                }
             }
         }
-
         // Apply the logical display configuration to the display device.
         if (display == null) {
             // TODO: no logical display for the device, blank it
@@ -1285,7 +1323,8 @@ public final class DisplayManagerService extends SystemService {
                     + device.getDisplayDeviceInfoLocked());
             return;
         }
-        display.configureDisplayLocked(t, device, info.state == Display.STATE_OFF);
+        display.configureDisplayLocked(t, device, info.state == Display.STATE_OFF,
+                layerStackOverride);
 
         // Update the viewports if needed.
         if (!mDefaultViewport.valid
@@ -1657,6 +1696,36 @@ public final class DisplayManagerService extends SystemService {
             final long token = Binder.clearCallingIdentity();
             try {
                 registerCallbackInternal(callback, callingPid);
+            } finally {
+                Binder.restoreCallingIdentity(token);
+            }
+        }
+
+        @Override // Binder call
+        public void enablePhoneMirroring() {
+            final long token = Binder.clearCallingIdentity();
+            try {
+                setPhoneMirroringEnabledInternal(true);
+            } finally {
+                Binder.restoreCallingIdentity(token);
+            }
+        }
+
+        @Override // Binder call
+        public void disablePhoneMirroring() {
+            final long token = Binder.clearCallingIdentity();
+            try {
+                setPhoneMirroringEnabledInternal(false);
+            } finally {
+                Binder.restoreCallingIdentity(token);
+            }
+        }
+
+        @Override // Binder call
+        public boolean isPhoneMirroringEnabled() {
+            final long token = Binder.clearCallingIdentity();
+            try {
+                return isPhoneMirroringEnabledInternal();
             } finally {
                 Binder.restoreCallingIdentity(token);
             }

--- a/services/core/java/com/android/server/display/LocalDisplayAdapter.java
+++ b/services/core/java/com/android/server/display/LocalDisplayAdapter.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2012 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -441,6 +443,15 @@ final class LocalDisplayAdapter extends DisplayAdapter {
 
                     if (res.getBoolean(com.android.internal.R.bool.config_localDisplaysPrivate)) {
                         mInfo.flags |= DisplayDeviceInfo.FLAG_PRIVATE;
+                    }
+                    /*
+                     * maru
+                     *
+                     * Debug hook to toggle maru changes.
+                     */
+                    if (SystemProperties.getBoolean("persist.maru.desktop.hdmi", true)) {
+                        /* HDMI displays are the default external display */
+                        mInfo.flags |= DisplayDeviceInfo.FLAG_DEFAULT_EXTERNAL_DISPLAY;
                     }
                 }
             }

--- a/services/core/java/com/android/server/display/LogicalDisplay.java
+++ b/services/core/java/com/android/server/display/LogicalDisplay.java
@@ -338,12 +338,15 @@ final class LogicalDisplay {
      *
      * @param device The display device to modify.
      * @param isBlanked True if the device is being blanked.
+     * @param layerStackOverride The layerstack to associate the device with, or
+     *                           < 0 to use the primary display device's layerstack
      */
     public void configureDisplayLocked(SurfaceControl.Transaction t,
             DisplayDevice device,
-            boolean isBlanked) {
+            boolean isBlanked, int layerStackOverride) {
         // Set the layer stack.
-        device.setLayerStackLocked(t, isBlanked ? BLANK_LAYER_STACK : mLayerStack);
+        int layerStack = layerStackOverride < 0 ? mLayerStack : layerStackOverride;
+        device.setLayerStackLocked(t, isBlanked ? BLANK_LAYER_STACK : layerStack);
 
         // Set the color mode and mode.
         if (device == mPrimaryDisplayDevice) {
@@ -423,6 +426,17 @@ final class LogicalDisplay {
         mTempDisplayRect.top += mDisplayOffsetY;
         mTempDisplayRect.bottom += mDisplayOffsetY;
         device.setProjectionLocked(t, orientation, mTempLayerStackRect, mTempDisplayRect);
+    }
+
+    /**
+     * Stock method signature that uses the associated physical display's layer stack as usual.
+     *
+     * @param t
+     * @param device
+     * @param isBlanked
+     */
+    public void configureDisplayLocked(SurfaceControl.Transaction t, DisplayDevice device, boolean isBlanked) {
+        configureDisplayLocked(t, device, isBlanked, -1);
     }
 
     /**

--- a/services/core/java/com/android/server/mperspective/PerspectiveService.java
+++ b/services/core/java/com/android/server/mperspective/PerspectiveService.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.server.mperspective;
+
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.mperspective.IPerspectiveService;
+import android.mperspective.IPerspectiveServiceCallback;
+import android.mperspective.Perspective;
+import android.os.Binder;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
+import android.os.RemoteException;
+import android.util.Log;
+import android.util.SparseArray;
+import android.view.Display;
+import com.android.server.FgThread;
+import com.android.server.SystemService;
+
+/**
+ * PerspectiveService is the central entity in perspective management.
+ *
+ * Instead of the standard industry practice of strong-coupling a specific
+ * interface to hardware, multiple perspectives can be managed (sometimes in parallel)
+ * to better make use of context.
+ *
+ * Currently, Maru defines a mobile and desktop perspective that can be
+ * run in parallel depending on the computing context of the user.
+ *
+ * Concurrency is handled by locking global state. All changes to state and
+ * subsequent side effects (e.g. dispatching lifecycle events to listeners or updating UI)
+ * are run under a single locked transaction.
+ *
+ * Note that the actual perspective lifecycle actions are carried out via
+ * JNI calls to a native perspectived daemon.
+ */
+public class PerspectiveService extends IPerspectiveService.Stub {
+
+    private static final String TAG = "PerspectiveService";
+
+    public static class Lifecycle extends SystemService {
+        private PerspectiveService mPerspectiveService;
+
+        public Lifecycle(Context context) {
+            super(context);
+        }
+
+        @Override
+        public void onStart() {
+            mPerspectiveService = new PerspectiveService(getContext());
+            publishBinderService(Context.PERSPECTIVE_SERVICE, mPerspectiveService);
+        }
+
+        @Override
+        public void onBootPhase(int phase) {
+            if (phase == SystemService.PHASE_ACTIVITY_MANAGER_READY) {
+                mPerspectiveService.systemReady();
+            }
+        }
+    }
+
+    private Context mContext;
+    private DisplayManager mDisplayManager;
+
+    // wrapper to sp<IPerspectiveService>
+    private long mNativeClient;
+
+    // global state lock
+    private final Object mLock = new Object();
+
+    private final SparseArray<CallbackWrapper> mCallbacks;
+
+    private int mDesktopState;
+
+    private boolean mHDMIAutoStart = true;
+    private final MDisplayListener mDisplayListener;
+
+    private final PerspectiveHandler mHandler;
+    private static final int MSG_START_DESKTOP = 0;
+    private static final int MSG_STOP_DESKTOP = 1;
+    private static final int MSG_UPDATE_DESKTOP_STATE = 2;
+
+    public PerspectiveService(Context context) {
+        mContext = context;
+        mDisplayListener = new MDisplayListener();
+        mCallbacks = new SparseArray<CallbackWrapper>();
+        mHandler = new PerspectiveHandler(FgThread.get().getLooper());
+    }
+
+    private void systemReady() {
+        mDisplayManager = (DisplayManager) mContext
+                .getSystemService(Context.DISPLAY_SERVICE);
+        mDisplayManager.registerDisplayListener(mDisplayListener, FgThread.getHandler());
+
+        mNativeClient = nativeCreateClient();
+    }
+
+    private void scheduleStartDesktopPerspective() {
+        mHandler.sendEmptyMessage(MSG_START_DESKTOP);
+    }
+
+    private void scheduleStopDesktopPerspective() {
+        mHandler.sendEmptyMessage(MSG_STOP_DESKTOP);
+    }
+
+    private void scheduleUpdateDesktopState() {
+        mHandler.sendEmptyMessage(MSG_UPDATE_DESKTOP_STATE);
+    }
+
+    private void updateDesktopStateLocked(int state) {
+        Log.d(TAG, "mDesktopState: " + Perspective.stateToString(mDesktopState)
+                + " -> " + Perspective.stateToString(state));
+        if (mDesktopState != state) {
+            mDesktopState = state;
+            dispatchEventLocked(state);
+        }
+    }
+
+    private void updateDesktopState() {
+        synchronized (mLock) {
+            boolean isRunning = nativeIsRunning(mNativeClient);
+            updateDesktopStateLocked(isRunning ? Perspective.STATE_RUNNING
+                    : Perspective.STATE_STOPPED);
+        }
+    }
+
+    private boolean isDesktopRunningInternal() {
+        synchronized (mLock) {
+            boolean isRunning = nativeIsRunning(mNativeClient);
+            int state = isRunning ? Perspective.STATE_RUNNING
+                    : Perspective.STATE_STOPPED;
+            if (mDesktopState != state) {
+                /*
+                 * Woops, there is a discrepancy: the desktop changed state
+                 * under our feet for some reason. The good thing is that this
+                 * should be a rare case.
+                 *
+                 * This could be fixed by polling nativeIsRunning but that seems
+                 * wasteful so we'll just wait for a client to force us to check.
+                 *
+                 * Schedule an update of our state on the system thread that will
+                 * sync up our state (provided there aren't any other pending lifecycle
+                 * tasks scheduled before us that sync us up before it even runs).
+                 */
+                Log.w(TAG, "Yikes, desktop unexpectedly changed state to "
+                        + Perspective.stateToString(state)
+                        + " (expected " + Perspective.stateToString(mDesktopState) + ")");
+                scheduleUpdateDesktopState();
+            }
+            return isRunning;
+        }
+    }
+
+    private void registerCallbackInternal(final IPerspectiveServiceCallback callback,
+                                          final int pid) {
+        synchronized (mLock) {
+            if (mCallbacks.get(pid) != null) {
+                Log.w(TAG, "pid " + pid + " already has a registered callback, will be updated");
+            }
+
+            CallbackWrapper callbackWrapper = new CallbackWrapper(callback, pid);
+            try {
+                IBinder binder = callback.asBinder();
+                binder.linkToDeath(callbackWrapper, 0);
+            } catch (RemoteException e) {
+                Log.e(TAG, "Failed to register callback for pid " + pid, e);
+                return;
+            }
+            mCallbacks.put(pid, new CallbackWrapper(callback, pid));
+        }
+    }
+
+    private void dispatchEventLocked(int event) {
+        for (int i = 0; i < mCallbacks.size(); ++i) {
+            mCallbacks.valueAt(i).dispatchEvent(event);
+        }
+    }
+
+    private void onCallbackDied(CallbackWrapper callbackWrapper) {
+        synchronized (mLock) {
+            mCallbacks.remove(callbackWrapper.mPid);
+        }
+    }
+
+    @Override // Binder call
+    public void startDesktopPerspective() {
+        scheduleStartDesktopPerspective();
+    }
+
+    @Override // Binder call
+    public void stopDesktopPerspective() {
+        scheduleStopDesktopPerspective();
+    }
+
+    @Override // Binder call
+    public boolean isDesktopRunning() {
+        return isDesktopRunningInternal();
+    }
+
+    @Override // Binder call
+    public void registerCallback(IPerspectiveServiceCallback callback) {
+        if (callback == null) {
+            throw new IllegalArgumentException("callback cannot be null");
+        }
+
+        registerCallbackInternal(callback, Binder.getCallingPid());
+    }
+
+    /**
+     * Convenience wrapper for managing client callback death.
+     */
+    private final class CallbackWrapper implements DeathRecipient {
+        private final IPerspectiveServiceCallback mCallback;
+        private final int mPid;
+
+        public CallbackWrapper(final IPerspectiveServiceCallback callback, final int pid) {
+            mCallback = callback;
+            mPid = pid;
+        }
+
+        @Override
+        public void binderDied() {
+            onCallbackDied(this);
+        }
+
+        public void dispatchEvent(int event) {
+            try {
+                mCallback.onPerspectiveEvent(event);
+            } catch (RemoteException e) {
+                Log.d(TAG, "Failed to dispatch event to pid " + mPid, e);
+                binderDied();
+            }
+        }
+    }
+
+    /**
+     * Defer most work here for a few reasons:
+     *  (1) Avoid blocking Binder clients for expensive tasks, particularly the UI thread
+     *  (2) Avoid permission issues running stuff under Binder client context
+     */
+    private class PerspectiveHandler extends Handler {
+        public PerspectiveHandler(Looper looper) {
+            super(looper);
+        }
+
+        private void startDesktopPerspectiveInternal() {
+            synchronized (mLock) {
+                if (mDesktopState == Perspective.STATE_STOPPED) {
+                    updateDesktopStateLocked(Perspective.STATE_STARTING);
+
+                    boolean res = nativeStart(mNativeClient);
+                    if (res) {
+                        updateDesktopStateLocked(Perspective.STATE_RUNNING);
+                    } else {
+                        // unlikely
+                        Log.e(TAG, "nativeStart failed");
+                        updateDesktopStateLocked(Perspective.STATE_STOPPED);
+                    }
+                }
+            }
+        }
+
+        private void stopDesktopPerspectiveInternal() {
+            synchronized (mLock) {
+                if (mDesktopState == Perspective.STATE_RUNNING) {
+                    updateDesktopStateLocked(Perspective.STATE_STOPPING);
+
+                    boolean res = nativeStop(mNativeClient);
+                    if (res) {
+                        updateDesktopStateLocked(Perspective.STATE_STOPPED);
+                    } else {
+                        // unlikely
+                        Log.e(TAG, "nativeStop failed");
+                        updateDesktopStateLocked(Perspective.STATE_RUNNING);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            switch (msg.what) {
+                case MSG_START_DESKTOP:
+                    startDesktopPerspectiveInternal();
+                    break;
+                case MSG_STOP_DESKTOP:
+                    stopDesktopPerspectiveInternal();
+                    break;
+                case MSG_UPDATE_DESKTOP_STATE:
+                    updateDesktopState();
+                    break;
+            }
+        }
+    }
+
+    private class MDisplayListener implements DisplayManager.DisplayListener {
+        // track the hdmi display id to check if it has been removed later
+        private int mHdmiDisplayId = -1;
+
+        @Override
+        public void onDisplayAdded(int displayId) {
+            Display display = mDisplayManager.getDisplay(displayId);
+            final boolean hdmiDisplayAdded = display.getType() == Display.TYPE_HDMI;
+
+            if (hdmiDisplayAdded) {
+                if (mHdmiDisplayId == -1) {
+                    mHdmiDisplayId = displayId;
+                    if (mHDMIAutoStart) {
+                        Log.i(TAG, "HDMI display added, scheduling desktop start...");
+                        scheduleStartDesktopPerspective();
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onDisplayRemoved(int displayId) {
+            if (displayId == mHdmiDisplayId) {
+                if (mHdmiDisplayId != -1) {
+                    mHdmiDisplayId = -1;
+                }
+            }
+        }
+
+        @Override
+        public void onDisplayChanged(int displayId) { /* no-op */ }
+    }
+
+    private static native long nativeCreateClient();
+    private static native boolean nativeStart(long ptr);
+    private static native boolean nativeStop(long ptr);
+    private static native boolean nativeIsRunning(long ptr);
+
+}

--- a/services/core/jni/Android.bp
+++ b/services/core/jni/Android.bp
@@ -50,12 +50,14 @@ cc_library_static {
         "com_android_server_PersistentDataBlockService.cpp",
         "com_android_server_GraphicsStatsService.cpp",
         "onload.cpp",
+        "com_android_server_mperspective_PerspectiveService.cpp",
     ],
 
     include_dirs: [
         "frameworks/base/libs",
         "frameworks/native/services",
         "system/gatekeeper/include",
+        "vendor/maruos/include",
     ],
 
     product_variables: {
@@ -131,6 +133,7 @@ cc_defaults {
         "android.frameworks.schedulerservice@1.0",
         "android.frameworks.sensorservice@1.0",
         "vendor.lineage.power@1.0",
+        "libperspective",
     ],
 
     static_libs: [

--- a/services/core/jni/com_android_server_mperspective_PerspectiveService.cpp
+++ b/services/core/jni/com_android_server_mperspective_PerspectiveService.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015-2016 Preetam J. D'Souza
+ * Copyright 2016 The Maru OS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Credits: Inspired by android_view_SurfaceSession.cpp.
+ */
+
+#define LOG_TAG "PerspectiveServiceJNI"
+
+#include <nativehelper/JNIHelp.h>
+
+#include <android_runtime/AndroidRuntime.h>
+#include <utils/Log.h>
+#include <utils/RefBase.h>
+
+#include <binder/IServiceManager.h>
+#include <perspective/IPerspectiveService.h>
+
+namespace android {
+
+static struct {
+    jfieldID mNativeClient;
+} gPerspectiveManagerClassInfo;
+
+
+/**
+ * Wrapper for IPerspectiveService Binder proxy.
+ *
+ * In order for us to preserve the Binder proxy between JNI calls
+ * we wrap up the proxy in this wrapper, allocate it on the heap,
+ * and store a pointer within the corresponding Java class that is
+ * passed as an arg to all subsequent calls.
+ *
+ * Error handling: if the remote does not exist, we always return false.
+ *
+ * *I think the sp<> handle adds a reference so that the object is
+ * not destroyed, i.e. we don't need to manually incStrong().
+ */
+class PerspectiveClient {
+public:
+    PerspectiveClient(sp<IPerspectiveService> proxy)
+        : mProxy(proxy) {
+        if (proxy != NULL) {
+            // listen for remote death
+            mDeathRecipient = new MDeathRecipient(*const_cast<PerspectiveClient*>(this));
+            IInterface::asBinder(mProxy)->linkToDeath(mDeathRecipient);
+        }
+    }
+
+    void remoteDied() {
+        mProxy = NULL;
+        mDeathRecipient = NULL;
+    }
+
+    bool start() {
+        return mProxy != NULL && mProxy->start();
+    }
+
+    bool stop() {
+        return mProxy != NULL && mProxy->stop();
+    }
+
+    bool isRunning() {
+        return mProxy != NULL && mProxy->isRunning();
+    }
+
+private:
+    sp<IPerspectiveService> mProxy;
+
+    class MDeathRecipient : public IBinder::DeathRecipient {
+        PerspectiveClient& mClient;
+        virtual void binderDied(const wp<IBinder>& who) {
+            ALOGW("PerspectiveService remote died [%p]",
+                  who.unsafe_get());
+            mClient.remoteDied();
+        }
+    public:
+        MDeathRecipient(PerspectiveClient& client) : mClient(client) { }
+    };
+    sp<MDeathRecipient> mDeathRecipient;
+};
+
+static jlong nativeCreateClient(JNIEnv* env, jclass clazz) {
+    sp<IPerspectiveService> client;
+    getService(String16("PerspectiveService"), &client);
+    if (client == NULL) {
+        ALOGE("Failed to get a handle to PerspectiveService from ServiceManager!");
+        // we go ahead and wrap up the null ptr anyway...our wrapper
+        // will always return false
+    }
+    PerspectiveClient *wrapper = new PerspectiveClient(client);
+    return reinterpret_cast<jlong>(wrapper);
+}
+
+static jboolean nativeStart(JNIEnv *env, jclass clazz, jlong ptr) {
+    PerspectiveClient *client = reinterpret_cast<PerspectiveClient*>(ptr);
+    return client->start();
+}
+
+static jboolean nativeStop(JNIEnv *env, jclass clazz, jlong ptr) {
+    PerspectiveClient *client = reinterpret_cast<PerspectiveClient*>(ptr);
+    return client->stop();
+}
+
+static jboolean nativeIsRunning(JNIEnv *env, jclass clazz, jlong ptr) {
+    PerspectiveClient *client = reinterpret_cast<PerspectiveClient*>(ptr);
+    return client->isRunning();
+}
+
+static JNINativeMethod gMethods[] = {
+    /* name, signature, funcPtr */
+    { "nativeCreateClient", "()J",
+            (void *)nativeCreateClient },
+    { "nativeStart", "(J)Z",
+            (void *)nativeStart },
+    { "nativeStop", "(J)Z",
+            (void *)nativeStop },
+    { "nativeIsRunning", "(J)Z",
+            (void *)nativeIsRunning }
+};
+
+int register_android_server_mperspective_PerspectiveService(JNIEnv* env) {
+    int res = jniRegisterNativeMethods(env, "com/android/server/mperspective/PerspectiveService",
+            gMethods, NELEM(gMethods));
+    LOG_ALWAYS_FATAL_IF(res < 0, "Unable to register native methods.");
+
+    jclass clazz = env->FindClass("com/android/server/mperspective/PerspectiveService");
+    gPerspectiveManagerClassInfo.mNativeClient = env->GetFieldID(clazz, "mNativeClient", "J");
+
+    return res;
+}
+
+} // namespace android

--- a/services/core/jni/onload.cpp
+++ b/services/core/jni/onload.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2009 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +59,9 @@ int register_android_server_net_NetworkStatsService(JNIEnv* env);
 #ifdef USE_ARC
 int register_android_server_ArcVideoService();
 #endif
+
+// maru
+int register_android_server_mperspective_PerspectiveService(JNIEnv* env);
 };
 
 using namespace android;
@@ -107,5 +112,8 @@ extern "C" jint JNI_OnLoad(JavaVM* vm, void* /* reserved */)
 #ifdef USE_ARC
     register_android_server_ArcVideoService();
 #endif
+    // maru
+    register_android_server_mperspective_PerspectiveService(env);
+
     return JNI_VERSION_1_4;
 }

--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2006 The Android Open Source Project
+ * Copyright (C) 2015-2016 Preetam J. D'Souza
+ * Copyright (C) 2016 The Maru OS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +89,7 @@ import com.android.server.media.MediaRouterService;
 import com.android.server.media.MediaUpdateService;
 import com.android.server.media.MediaSessionService;
 import com.android.server.media.projection.MediaProjectionManagerService;
+import com.android.server.mperspective.PerspectiveService;
 import com.android.server.net.NetworkPolicyManagerService;
 import com.android.server.net.NetworkStatsService;
 import com.android.server.net.watchlist.NetworkWatchlistService;
@@ -1356,6 +1359,15 @@ public final class SystemServer {
                 Slog.e(TAG, "Failure starting HardwarePropertiesManagerService", e);
             }
             traceEnd();
+            if (!mOnlyCore) {
+                traceBeginAndSlog("StartPerspectiveService");
+                try {
+                    mSystemServiceManager.startService(PerspectiveService.Lifecycle.class);
+                } catch (Throwable e) {
+                    reportWtf("starting PerspectiveService", e);
+                }
+                traceEnd();
+            }
 
             traceBeginAndSlog("StartTwilightService");
             mSystemServiceManager.startService(TwilightService.class);


### PR DESCRIPTION
Port display modifications for maru. I don't port notification part for it, because we will port it to settings app.

Test: Open a simulated display from developer options, and use `lxc-start --name default` from terminal, the simulated display shows the Linux desktop correctly.

@pdsouza , I want to rebase all patches to one actually, and do simple cleanup for it.