### PR TITLE
Enable dynamic input switching

### DIFF
--- a/services/core/jni/com_android_server_mperspective_PerspectiveService.cpp
+++ b/services/core/jni/com_android_server_mperspective_PerspectiveService.cpp
@@ -76,6 +76,10 @@ public:
         return mProxy != NULL && mProxy->isRunning();
     }
 
+    bool enableInput(bool enable) {
+        return mProxy != NULL && mProxy->enableInput(enable);
+    }
+
 private:
     sp<IPerspectiveService> mProxy;
 
@@ -119,6 +123,11 @@ static jboolean nativeIsRunning(JNIEnv *env, jclass clazz, jlong ptr) {
     return client->isRunning();
 }
 
+static jboolean nativeEnableInput(JNIEnv *env, jclass clazz, jlong ptr, jboolean enable) {
+    PerspectiveClient *client = reinterpret_cast<PerspectiveClient*>(ptr);
+    return client->enableInput(enable);
+}
+
 static JNINativeMethod gMethods[] = {
     /* name, signature, funcPtr */
     { "nativeCreateClient", "()J",
@@ -128,7 +137,9 @@ static JNINativeMethod gMethods[] = {
     { "nativeStop", "(J)Z",
             (void *)nativeStop },
     { "nativeIsRunning", "(J)Z",
-            (void *)nativeIsRunning }
+            (void *)nativeIsRunning },
+    { "nativeEnableInput", "(JZ)Z",
+            (void *)nativeEnableInput}
 };
 
 int register_android_server_mperspective_PerspectiveService(JNIEnv* env) {


### PR DESCRIPTION
When desktop is interactive, we will disable external input devices, and
enable those devices when desktop is non-interactive.

Default, the Android don't show IME when hardware
keyboard is connected. But when desktop is interactive,
the hardware keyboard event is directed to desktop,
so we need showing IME when desktop is interactive
for better user experience.

Note: this CL is squashed from three commits about dynamic input
switching from maru-0.6, and use new API of `InputManager` to simply the
logic.