### PR TITLE
Add desktop notification

### DIFF
--- a/core/res/res/drawable/ic_mdesktop.xml
+++ b/core/res/res/drawable/ic_mdesktop.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (C) 2015-2016 Preetam J. D'Souza
+    Copyright (C) 2016 The Maru OS Project
+
+    This work is licensed under the Creative Commons Attribution 4.0
+    International License (CC-BY 4.0). To view a copy of the license, visit
+
+    https://creativecommons.org/licenses/by/4.0/
+
+    Derived from Material Design icon "desktop windows"
+    https://design.google.com/icons/#ic_desktop_windows
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="48dp"
+        android:height="48dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M21,2H3c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h7v2H8v2h8v-2h-2v-2h7c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2zm0,14H3V4h18v12z"/>
+</vector>

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -4995,4 +4995,10 @@
     <!-- Strings for car -->
     <!-- String displayed when loading a user in the car [CHAR LIMIT=30] -->
     <string name="car_loading_profile">Loading</string>
+    <!-- maru -->
+    <string name="desktop_notification_title_starting">Maru Desktop starting...</string>
+    <string name="desktop_notification_title_stopping">Maru Desktop stopping...</string>
+    <string name="desktop_notification_title_running">Maru Desktop running</string>
+    <string name="desktop_notification_msg">Touch to manage desktop settings.</string>
+    <!-- /maru -->
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -3425,4 +3425,12 @@
   <java-symbol type="integer" name="db_wal_truncate_size" />
 
   <java-symbol type="string" name="config_defaultAssistantComponentName" />
+  <!-- maru -->
+  <!-- From PerspectiveService -->
+  <java-symbol type="string" name="desktop_notification_title_starting" />
+  <java-symbol type="string" name="desktop_notification_title_stopping" />
+  <java-symbol type="string" name="desktop_notification_title_running" />
+  <java-symbol type="string" name="desktop_notification_msg" />
+  <java-symbol type="drawable" name="ic_mdesktop" />
+  <!-- /maru -->
 </resources>


### PR DESCRIPTION
It's not easy to manage system-alert level notification on `MaruSettings` when desktop perspective state changed. So I also implement it on `frameworks/base` and bind it with `MaruSettings`' desktop settings activity.